### PR TITLE
[WIP][IGNORE]QPT-35051: Adding the event loop to the tcp connector

### DIFF
--- a/stitch_connect_client/rest.py
+++ b/stitch_connect_client/rest.py
@@ -68,7 +68,7 @@ class RESTClientObject(object):
             ssl_context.verify_mode = ssl.CERT_NONE
 
         loop = asyncio.get_event_loop()
-        print("\n\n\n\n\n-----------------------------")
+        print("\n\n\n\n\nSTITCH-----------------------------")
         print(loop)
         print("-----------------------------\n\n\n\n\n")
         connector = aiohttp.TCPConnector(limit=maxsize, ssl=ssl_context, loop=loop)

--- a/stitch_connect_client/rest.py
+++ b/stitch_connect_client/rest.py
@@ -68,7 +68,9 @@ class RESTClientObject(object):
             ssl_context.verify_mode = ssl.CERT_NONE
 
         loop = asyncio.get_event_loop()
-        logger.debug(f"The running asyncio loop: {loop}")
+        print("\n\n\n\n\n-----------------------------")
+        print(loop)
+        print("-----------------------------\n\n\n\n\n")
         connector = aiohttp.TCPConnector(limit=maxsize, ssl=ssl_context, loop=loop)
 
         # https pool manager

--- a/stitch_connect_client/rest.py
+++ b/stitch_connect_client/rest.py
@@ -67,7 +67,9 @@ class RESTClientObject(object):
             ssl_context.check_hostname = False
             ssl_context.verify_mode = ssl.CERT_NONE
 
-        connector = aiohttp.TCPConnector(limit=maxsize, ssl=ssl_context)
+        loop = asyncio.get_event_loop()
+        logger.debug(f"The running asyncio loop: {loop}")
+        connector = aiohttp.TCPConnector(limit=maxsize, ssl=ssl_context, loop=loop)
 
         # https pool manager
         if configuration.proxy:

--- a/stitch_connect_client/rest.py
+++ b/stitch_connect_client/rest.py
@@ -70,6 +70,7 @@ class RESTClientObject(object):
         loop = asyncio.get_event_loop()
         print("\n\n\n\n\nSTITCH-----------------------------")
         print(loop)
+        print(asyncio.Task.current_task(loop=loop))
         print("-----------------------------\n\n\n\n\n")
         connector = aiohttp.TCPConnector(limit=maxsize, ssl=ssl_context, loop=loop)
 


### PR DESCRIPTION
# Overview:
The rest.py ClientSession() object uses a TCPConnector() object that does not pass a running loop downstream if it exists. 